### PR TITLE
Support multiple platforms for kubectl

### DIFF
--- a/kubectl/kubectl_test.go
+++ b/kubectl/kubectl_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tjamet/kubectl-switch/kubectl"
-	"github.com/tjamet/xgo/xtesting"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -45,13 +45,17 @@ func TestURL(t *testing.T) {
 }
 
 func TestPath(t *testing.T) {
-	defer xtesting.NoEnv("HOME")()
-	defer xtesting.InEnv("USERPROFILE", "./test-home")()
-	assert.Equal(t, "./test-home/.kube/bin/kubectl-1.10.0", kubectl.Path("1.10.0"))
+	t.Cleanup(kubectl.Reset)
+	kubectl.HomeDir = func() string { return "./test-home" }
+	path := kubectl.Path("1.10.0")
+
+	assert.Equal(t, "test-home/.kube/bin", filepath.Dir(path))
+	assert.Equal(t, []string{"kubectl", runtime.GOOS, runtime.GOARCH, "1.10.0"}, strings.Split(filepath.Base(path), "-"))
 }
 
 func TestDownload(t *testing.T) {
-	defer xtesting.InEnv("HOME", "./test-home")()
+	t.Cleanup(kubectl.Reset)
+	kubectl.HomeDir = func() string { return "./test-home" }
 	assert.False(t, kubectl.Installed("test-some-version"))
 	t.Run("When the server returns a 404, kubectl is not installed", func(t *testing.T) {
 		defaultTransport := http.DefaultTransport
@@ -70,19 +74,20 @@ func TestDownload(t *testing.T) {
 }
 
 func TestDownloadAndRun(t *testing.T) {
-	defer xtesting.InEnv("HOME", "./test-home")()
+	t.Cleanup(kubectl.Reset)
+	kubectl.HomeDir = func() string { return "./test-home" }
 	assert.False(t, kubectl.Installed("test-some-version"))
 	t.Run("When kubectl returns an error, Run returns the status code", func(t *testing.T) {
 		defer mockKubectl(t, 1)()
 		assert.NoError(t, kubectl.Download("0.0.0.1"))
-		assert.FileExists(t, "./test-home/.kube/bin/kubectl-0.0.0.1")
+		assert.FileExists(t, kubectl.Path("0.0.0.1"))
 		assert.Equal(t, 1, kubectl.Exec("0.0.0.1"))
 		assert.True(t, kubectl.Installed("0.0.0.1"))
 	})
 	t.Run("When kubectl returns an error, Run returns the status code", func(t *testing.T) {
 		defer mockKubectl(t, 0)()
 		assert.NoError(t, kubectl.Download("0.0.0.2"))
-		assert.FileExists(t, "./test-home/.kube/bin/kubectl-0.0.0.2")
+		assert.FileExists(t, kubectl.Path("0.0.0.2"))
 		assert.Equal(t, 0, kubectl.Exec("0.0.0.2"))
 	})
 	t.Run("Arguments are forwarded to kubectl", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ func (n nopWriter) Write(a []byte) (int, error) {
 }
 
 func main() {
-
 	cmds := &cobra.Command{}
 
 	flags := cmds.PersistentFlags()


### PR DESCRIPTION
In order to provide a Docker image fot kubectl-switch, we need to support
the case where kubectl-switch is run in a linuc container, mounting the
kube config volume from either a mac or a windows, and in a different
architecture.

This commit is a first step in to enable such  docker images
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Rework file structure (#5)
</summary>
Make more explicit what are packages and what are binaries to be
compiled.

Package utilities inside pkg
Group binaries inside cmd

Provide a backward compatible `main.go` entrypoint
</details>
<details>
<summary>
Add Dockerfile (#6)
</summary>
Add a Dockerfile to be able to run kubectl-switch within docker.

This image runs a distroless application and hence the config files
should be mounted in `/home/nonroot/.kube` with read/write permissions

to allow simply runnning the container as any other command line tool
</details>
</details>
</details>